### PR TITLE
change shebangs of all .sh scripts to bash

### DIFF
--- a/doc/manual/process-includes.sh
+++ b/doc/manual/process-includes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/doc/manual/render-manpage.sh
+++ b/doc/manual/render-manpage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/maintainers/buildtime_report.sh
+++ b/maintainers/buildtime_report.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Generates a report of build time based on a meson build using -ftime-trace in
 # Clang.

--- a/tests/functional/install-darwin.sh
+++ b/tests/functional/install-darwin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -eux
 

--- a/tests/functional/nix-daemon-untrusting.sh
+++ b/tests/functional/nix-daemon-untrusting.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 exec nix-daemon --force-untrusted "$@"

--- a/tests/functional/push-to-store-old.sh
+++ b/tests/functional/push-to-store-old.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -x
 set -e

--- a/tests/functional/push-to-store.sh
+++ b/tests/functional/push-to-store.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -x
 set -e


### PR DESCRIPTION
On operating systems where /bin/sh is not Bash, some scripts are invalid
because of bashisms, and building Lix fails with errors like this:
`render-manpage.sh: 3: set: Illegal option -o pipefail`
This modifies all scripts that use a `/bin/sh` shebang to `/usr/bin/env
bash`, including currently POSIX-compliant ones, to prevent any future
confusion.

Change-Id: Ia074cc6db42d40fc59a63726f6194ea0149ea5e0
