### PR TITLE
Improve "illegal path references in fixed output derivation" error

### DIFF
--- a/lix/libstore/build/local-derivation-goal.cc
+++ b/lix/libstore/build/local-derivation-goal.cc
@@ -2251,10 +2251,14 @@ try {
                             wanted.to_string(Base::SRI, true),
                             got.to_string(Base::SRI, true)));
                 }
-                if (!newInfo0.references.empty())
+                if (!newInfo0.references.empty()) {
+                    auto numViolations = newInfo.references.size();
                     delayedException = std::make_exception_ptr(
-                        BuildError("illegal path references in fixed-output derivation '%s'",
-                            worker.store.printStorePath(drvPath)));
+                        BuildError("fixed-output derivations must not reference store paths: '%s' references %d distinct paths, e.g. '%s'",
+                            worker.store.printStorePath(drvPath),
+                            numViolations,
+                            worker.store.printStorePath(*newInfo.references.begin())));
+                }
 
                 return newInfo0;
             },


### PR DESCRIPTION
This was just merged into nix, see:
- https://github.com/NixOS/nix/issues/11673
- https://github.com/NixOS/nix/pull/12356

I've asked about this on Matrix and to the best of my knowledge there's no automatic means by which Nix patches make it over here, so I thought I'd just make the PR again. Happy for this to be closed / ignored if the change would make it into Lix eventually regardless.

I also haven't specifically tested this in Lix. I tested that it built but since it's a simple change, I'm hoping you'll find the Nix testing sufficient. Let me know if not (though realistically I might not have time to do more particularly soon.)

# Motivation
Improving a somewhat-maligned Nix error message (the issue above has links to people complaining about this one).